### PR TITLE
fix Update treesToRoots.js

### DIFF
--- a/cli/defaultOperatorRewards/treesToRoots.js
+++ b/cli/defaultOperatorRewards/treesToRoots.js
@@ -11,7 +11,7 @@ function parseMerkleTrees() {
     const values = tokenData.tree.values.map(
       ({ value: [operator, reward] }) => [operator, reward]
     )
-    const tree = StandardMerkleTree.of(values, ['address', 'uint256'])
+    const tree = StandardMerkleTree.load(tokenData.tree);
     trees[tokenData.token] = { tree, values }
   })
 


### PR DESCRIPTION
replaces the incorrect use of StandardMerkleTree.of(...) with StandardMerkleTree.load(...) when parsing previously generated Merkle trees from trees.json.

Previously, the code re-generated the tree from values, which may lead to an incorrect Merkle root if the order of values changes. This PR ensures that the exact original tree structure (including order and metadata) is preserved and loaded properly for consistent verification.

Use StandardMerkleTree.load(...) instead of StandardMerkleTree.of(...) in parseMerkleTrees()

Preserve original value structure from tree.values

The Merkle root and inclusion proofs must match what was originally committed. Regenerating the tree can cause mismatches due to different value ordering or structure, breaking compatibility with smart contracts or external verifiers.